### PR TITLE
feat(events): add parsed start_date and end_date fields to event info

### DIFF
--- a/betterdocs/app/(home)/page.tsx
+++ b/betterdocs/app/(home)/page.tsx
@@ -12,7 +12,7 @@ export default function HomePage() {
         <div className="mb-8 flex flex-wrap items-center justify-center gap-3">
           <div className="inline-flex items-center border border-border bg-background/50 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm">
             <span className="mr-2 inline-block h-1.5 w-1.5 bg-green-500"></span>
-            v1.6.0
+            v1.6.1
           </div>
           <div className="inline-flex items-center border border-border bg-background/50 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm">
             <span className="mr-2">🐍</span>

--- a/betterdocs/content/docs/api/events/info.mdx
+++ b/betterdocs/content/docs/api/events/info.mdx
@@ -62,6 +62,14 @@ Returns event header information or `None` if the event is not found.
       type: 'str | None',
       description: 'Human-readable date range (e.g., "May 20 - Jun 15, 2024")',
     },
+    start_date: {
+      type: 'date | None',
+      description: 'Parsed start date of the event',
+    },
+    end_date: {
+      type: 'date | None',
+      description: 'Parsed end date of the event',
+    },
     prize: {
       type: 'str | None',
       description: 'Prize pool with currency formatting (e.g., "$1,000,000 USD")',
@@ -86,7 +94,7 @@ Returns event header information or `None` if the event is not found.
 import vlrdevapi as vlr
 
 # Get event details
-event = vlr.events.info(event_id=2498)
+event = vlr.events.info(event_id=2283)
 
 if event:
     print(f"Event: {event.name}")
@@ -96,6 +104,12 @@ if event:
     print(f"Prize Pool: {event.prize or 'Not announced'}")
     print(f"Location: {event.location or 'Online'}")
     print(f"Dates: {event.date_text or 'TBD'}")
+    
+    # Access parsed dates
+    if event.start_date:
+        print(f"Start Date: {event.start_date}")  # datetime.date object
+    if event.end_date:
+        print(f"End Date: {event.end_date}")  # datetime.date object
     
     if event.regions:
         print(f"Regions: {', '.join(event.regions)}")

--- a/betterdocs/content/docs/api/events/list-events.mdx
+++ b/betterdocs/content/docs/api/events/list-events.mdx
@@ -5,6 +5,7 @@ description: List events with filters for tier, region, and status
 
 import { TypeTable } from 'fumadocs-ui/components/type-table';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+import { Callout } from 'fumadocs-ui/components/callout';
 import { Cards, Card } from 'fumadocs-ui/components/card';
 import { Info, ListChecks, Trophy } from 'lucide-react';
 
@@ -167,6 +168,14 @@ for event in events:
 - **No results**: Returns an empty list `[]`
 
 The function never raises exceptions, making it safe to use without try-catch blocks.
+
+## Date Parsing
+
+<Callout type="info">
+  The `list_events()` function uses the `info()` function internally to obtain accurate dates with correct years. This fixes an issue where past events were incorrectly assigned the current year when only partial date information was available in the event listing.
+</Callout>
+
+The `start_date` and `end_date` fields are parsed from the event's date text and include the correct year, making them reliable for filtering and sorting events by date.
 
  
 

--- a/docs/source/api/events.rst
+++ b/docs/source/api/events.rst
@@ -175,10 +175,16 @@ Get Event Details
    import vlrdevapi as vlr
 
    # Get event information
-   info = vlr.events.info(event_id=2498)
+   info = vlr.events.info(event_id=2283)
    print(f"{info.name}")
    print(f"Prize: {info.prize}")
    print(f"Location: {info.location}")
+   
+   # Access parsed dates
+   if info.start_date:
+       print(f"Start Date: {info.start_date}")
+   if info.end_date:
+       print(f"End Date: {info.end_date}")
 
 Get Event Matches
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -69,6 +69,20 @@ Many fields are optional and may be None:
    else:
        print("Date not available")
 
+Date fields on event info are also optional:
+
+.. code-block:: python
+
+   import vlrdevapi as vlr
+
+   # Get event info with parsed dates
+   event = vlr.events.info(event_id=2283)
+   
+   if event.start_date and event.end_date:
+       duration = (event.end_date - event.start_date).days
+       print(f"Event duration: {duration} days")
+       print(f"From {event.start_date} to {event.end_date}")
+
 Lists and Nested Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ author = 'Vansh'
 try:
     release = _metadata.version("vlrdevapi")
 except _metadata.PackageNotFoundError:
-    release = "1.6.0"
+    release = "1.6.1"
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vlrdevapi"
-version = "1.6.0"
+version = "1.6.1"
 description = "The comprehensive Python library for VLR.gg Valorant esports data scraping - tournaments, matches, players, and statistics"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vlrdevapi/__init__.py
+++ b/src/vlrdevapi/__init__.py
@@ -27,7 +27,7 @@ Example usage:
     ...     print(f"{member.ign} - {member.role}")
 """
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 # Configure stdout/stderr error handling without changing the environment's encoding.
 # This avoids UnicodeEncodeError on legacy consoles while preventing decoding mismatches

--- a/src/vlrdevapi/events/models.py
+++ b/src/vlrdevapi/events/models.py
@@ -67,6 +67,8 @@ class Info:
     name: str
     subtitle: str | None = None
     date_text: str | None = None
+    start_date: datetime.date | None = None
+    end_date: datetime.date | None = None
     prize: str | None = None
     location: str | None = None
     regions: list[str] = field(default_factory=list)

--- a/src/vlrdevapi/series/info.py
+++ b/src/vlrdevapi/series/info.py
@@ -102,8 +102,27 @@ def info(match_id: int, timeout: float | None = None) -> Info | None:
     # Teams and scores
     t1_link = header.select_one(".match-header-link.mod-1")
     t2_link = header.select_one(".match-header-link.mod-2")
-    t1 = extract_text(header.select_one(".match-header-link.mod-1 .wf-title-med"))
-    t2 = extract_text(header.select_one(".match-header-link.mod-2 .wf-title-med"))
+    
+    # Extract team names - get only direct text content, not nested divs
+    # The .wf-title-med may contain nested divs like "(Team Name)" that we want to exclude
+    t1_title_el = header.select_one(".match-header-link.mod-1 .wf-title-med")
+    t2_title_el = header.select_one(".match-header-link.mod-2 .wf-title-med")
+    
+    def extract_direct_text(element) -> str:
+        """Extract only direct text content from element, excluding nested elements."""
+        if not element:
+            return ""
+        # Get only direct text nodes (not text from nested elements)
+        direct_text = "".join(
+            str(child) for child in element.children 
+            if isinstance(child, str)
+        ).strip()
+        # Fallback to full text if no direct text found
+        return direct_text if direct_text else extract_text(element)
+    
+    t1 = extract_direct_text(t1_title_el)
+    t2 = extract_direct_text(t2_title_el)
+    
     t1_href = t1_link.get("href") if t1_link else None
     t2_href = t2_link.get("href") if t2_link else None
     t1_href = t1_href if isinstance(t1_href, str) else None


### PR DESCRIPTION
Add date parsing functionality to convert date_text strings into actual datetime.date objects. The Info model now includes start_date and end_date fields that are parsed from the date range text.

Update list_events() to use a three-tier fallback system for date accuracy:
- Primary: fetch dates from event info page (includes correct year)
- Secondary: parse from listing page text
- Tertiary: fetch from matches page as last resort

Also fix team name extraction in series module to handle nested elements and improve team metadata matching with multi-strategy approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.6.1

* **New Features**
  * Added optional `start_date` and `end_date` fields to event details for improved date handling

* **Documentation**
  * Updated API documentation with new date field descriptions and examples
  * Added date parsing guidance for event filtering and sorting

* **Improvements**
  * Enhanced team name extraction reliability
  * Improved team metadata matching with multi-strategy resolution

* **Chores**
  * Version bumped to 1.6.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->