### PR TITLE
Bump to v2.0.1: fix parsers for vlr.gg HTML changes, remove fkpr/fdpr…

### DIFF
--- a/docs-py/docs/changelog.md
+++ b/docs-py/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this page.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
@@ -41,49 +41,49 @@ The API surface, module structure, and type system are all new.
 
 ### Added
 
-- **Sync-first client** - `VLRClient` with context manager support and
+- **Sync-first client** — `VLRClient` with context manager support and
   thread-safe parallel enrichment for bulk operations.
-- **Curried access pattern** - bind a player/team/series/event ID once,
+- **Curried access pattern** — bind a player/team/series/event ID once,
   then chain sub-methods without re-passing the ID.
-- **Event namespace** - list with pagination and filtering (tier, region,
+- **Event namespace** — list with pagination and filtering (tier, region,
   status), plus info, matches, stages, standings, and teams.
-- **Match listing namespace** - live, upcoming (paginated), and completed
+- **Match listing namespace** — live, upcoming (paginated), and completed
   (paginated) match feeds with team enrichment.
-- **Player namespace** - info, teams (current/past), agent stats
+- **Player namespace** — info, teams (current/past), agent stats
   (30d/60d/90d/all), match history (paginated), and consolidated profile.
-- **Series namespace** - info (veto, games, scores), player stats per game,
+- **Series namespace** — info (veto, games, scores), player stats per game,
   round-by-round data, performance (kill matrices, advanced stats),
   economy (buy types, spend analysis), and VOD links.
-- **Team namespace** - info, roster, stats (per-map with optional agent
+- **Team namespace** — info, roster, stats (per-map with optional agent
   composition), placements, transactions, completed and upcoming matches.
-- **Pydantic v2 models** - fully typed with Google-style docstrings and
+- **Pydantic v2 models** — fully typed with Google-style docstrings and
   field descriptions.
-- **Built-in resilience** - configurable retry with exponential/linear/
+- **Built-in resilience** — configurable retry with exponential/linear/
   constant backoff, jitter, and token-bucket rate limiting.
-- **Thread-safe LRU cache** - bounded `LRUCache` for team data to avoid
+- **Thread-safe LRU cache** — bounded `LRUCache` for team data to avoid
   redundant HTTP requests during enrichment.
-- **Input validation** - `@sanitize_and_validate` decorator with positive-ID
+- **Input validation** — `@sanitize_and_validate` decorator with positive-ID
   checks and Pydantic type coercion.
-- **Custom exceptions** - typed hierarchy (`NotFoundError`, `RateLimitError`,
+- **Custom exceptions** — typed hierarchy (`NotFoundError`, `RateLimitError`,
   `ParsingError`, `ValidationError`, etc.) for clean error handling.
-- **Documentation** - Zensical/MkDocs site via `docs-py/` (ReadTheDocs)
+- **Documentation** — Zensical/MkDocs site via `docs-py/` (ReadTheDocs)
   with auto-generated API reference from docstrings.
-- **Official website** - Next.js + Fumadocs site via `official-docs/`
+- **Official website** — Next.js + Fumadocs site via `official-docs/`
   (Cloudflare Pages) with interactive code examples.
-- **Doc validation** - `scripts/check_mdx_examples.py` validates syntax,
+- **Doc validation** — `scripts/check_mdx_examples.py` validates syntax,
   imports, and live execution of all code examples in docs.
 
 ### Changed
 
-- **Architecture** - migrated from async aiohttp to synchronous httpx.
+- **Architecture** — migrated from async aiohttp to synchronous httpx.
   No more `await` or `async with` required.
-- **No explicit session management** - `VLRClient` handles connection
+- **No explicit session management** — `VLRClient` handles connection
   pooling, retries, and rate limiting internally.
-- **Type system** - replaced raw dict returns with Pydantic v2 models
+- **Type system** — replaced raw dict returns with Pydantic v2 models
   for all endpoints.
-- **Build system** - moved from setuptools to hatchling with `uv` for
+- **Build system** — moved from setuptools to hatchling with `uv` for
   dependency management.
-- **Python requirement** - raised minimum to 3.11.
+- **Python requirement** — raised minimum to 3.11.
 
 ### Removed
 
@@ -91,6 +91,3 @@ The API surface, module structure, and type system are all new.
   are removed. See the new module-level or client-based API.
 - `aiohttp` and `asyncio` dependencies.
 - v1.x match/event/team parsing modules.
-
-[2.0.1]: https://github.com/Vanshbordia/vlrdevapi/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/Vanshbordia/vlrdevapi/compare/v1.6.2...v2.0.0

--- a/docs-py/zensical.toml
+++ b/docs-py/zensical.toml
@@ -64,6 +64,7 @@ nav = [
     { "Series" = "api/series.md" },
     { "Teams" = "api/teams.md" },
   ]},
+  { "Changelog" = "changelog.md" },
 ]
 
 # With the "extra_css" option you can add your own CSS styling to customize

--- a/official-docs/app/(home)/changelog/page.tsx
+++ b/official-docs/app/(home)/changelog/page.tsx
@@ -8,6 +8,19 @@ export const metadata: Metadata = {
 
 const versions = [
   {
+    version: '2.0.1',
+    date: '29 July 2026',
+    summary: 'Maintenance release removing deprecated agent stat fields removed by vlr.gg and updating CSS selectors for the latest site markup.',
+    sections: [
+      {
+        title: 'Removed',
+        items: [
+          '`fkpr` and `fdpr` fields from `AgentStats` — vlr.gg consolidated the separate "First Kills Per Round" and "First Deaths Per Round" columns into a single "FK:FD" ratio. Use the existing `first_kills` and `first_deaths` total fields instead.',
+        ],
+      },
+    ],
+  },
+  {
     version: '2.0.0',
     date: '7 July 2026',
     summary: 'Initial release of VLRdevAPI. A type-safe Python SDK for Valorant esports data from VLR.gg.',

--- a/official-docs/components/home/terminal-demo.tsx
+++ b/official-docs/components/home/terminal-demo.tsx
@@ -14,7 +14,7 @@ export function TerminalDemo() {
         '...     print(f"    {m.team1.name:20s} vs {m.team2.name:20s}")',
       ]}
       outputs={{
-        0: ['Successfully installed vlrdevapi-2.0.0'],
+        0: ['Successfully installed vlrdevapi-2.0.1'],
         1: ['Python 3.12.0 (main, Oct 2 2024)'],
         5: [
           'Sentinels           vs NRG',

--- a/official-docs/content/docs/reference/player/agents.mdx
+++ b/official-docs/content/docs/reference/player/agents.mdx
@@ -112,18 +112,6 @@ player.agents(
     typeDescription: "float | None",
     default: "None",
   },
-  "fkpr": {
-    description: "First Kills per Round.",
-    type: "float | None",
-    typeDescription: "float | None",
-    default: "None",
-  },
-  "fdpr": {
-    description: "First Deaths per Round.",
-    type: "float | None",
-    typeDescription: "float | None",
-    default: "None",
-  },
   "kills": {
     description: "Total kills.",
     type: "int | None",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vlrdevapi"
-version = "2.0.0"
+version = "2.0.1"
 description = "A Python library to scrape data from vlr.gg"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vlrdevapi/__init__.py
+++ b/src/vlrdevapi/__init__.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     matches: MatchesNamespace
     client: type[VLRClient]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 _default_client: "VLRClient | None" = None
 

--- a/src/vlrdevapi/_player/_common_parsing.py
+++ b/src/vlrdevapi/_player/_common_parsing.py
@@ -139,7 +139,7 @@ def _parse_agent_row(tr: Node) -> AgentStats:
     stats = AgentStats()
     tds = tr.css("td")
 
-    if len(tds) < 17:
+    if len(tds) < 16:
         return stats
 
     img_el = tds[0].css_first("img")
@@ -160,12 +160,10 @@ def _parse_agent_row(tr: Node) -> AgentStats:
     stats.kast = tds[7].text(strip=True)
     stats.kpr = _parse_float(tds[8].text(strip=True))
     stats.apr = _parse_float(tds[9].text(strip=True))
-    stats.fkpr = _parse_float(tds[10].text(strip=True))
-    stats.fdpr = _parse_float(tds[11].text(strip=True))
-    stats.kills = _parse_int(tds[12].text(strip=True))
-    stats.deaths = _parse_int(tds[13].text(strip=True))
-    stats.assists = _parse_int(tds[14].text(strip=True))
-    stats.first_kills = _parse_int(tds[15].text(strip=True))
-    stats.first_deaths = _parse_int(tds[16].text(strip=True))
+    stats.kills = _parse_int(tds[11].text(strip=True))
+    stats.deaths = _parse_int(tds[12].text(strip=True))
+    stats.assists = _parse_int(tds[13].text(strip=True))
+    stats.first_kills = _parse_int(tds[14].text(strip=True))
+    stats.first_deaths = _parse_int(tds[15].text(strip=True))
 
     return stats

--- a/src/vlrdevapi/_player/agents/models.py
+++ b/src/vlrdevapi/_player/agents/models.py
@@ -18,8 +18,6 @@ class AgentStats(BaseModel):
     kast: str = Field(default="", description="Kill, Assist, Survive, Trade %")
     kpr: float | None = Field(default=None, description="Kills Per Round")
     apr: float | None = Field(default=None, description="Assists Per Round")
-    fkpr: float | None = Field(default=None, description="First Kills Per Round")
-    fdpr: float | None = Field(default=None, description="First Deaths Per Round")
     kills: int | None = Field(default=None, description="Total kills")
     deaths: int | None = Field(default=None, description="Total deaths")
     assists: int | None = Field(default=None, description="Total assists")

--- a/src/vlrdevapi/_player/agents/parser.py
+++ b/src/vlrdevapi/_player/agents/parser.py
@@ -16,7 +16,7 @@ def parse_agent_stats(html: HTMLParser, timespan: str = "all") -> AgentStatsPage
             card = _next_sibling_card(search_from)
             if card is None:
                 break
-            table = card.css_first("table.wf-table")
+            table = card.css_first("table.st-table.mod-agent-rows")
             if table is None:
                 break
             tbody = table.css_first("tbody")

--- a/src/vlrdevapi/_player/profile/parser.py
+++ b/src/vlrdevapi/_player/profile/parser.py
@@ -69,7 +69,7 @@ def _parse_agents(html: HTMLParser, profile: PlayerProfile) -> None:
             card = _next_sibling_card(search_from)
             if card is None:
                 break
-            table = card.css_first("table.wf-table")
+            table = card.css_first("table.st-table.mod-agent-rows")
             if table is None:
                 break
             tbody = table.css_first("tbody")

--- a/src/vlrdevapi/_series/players/parser.py
+++ b/src/vlrdevapi/_series/players/parser.py
@@ -138,119 +138,137 @@ def _parse_stat_cell(td: Node) -> tuple:
     return overall, attack, defend
 
 
-def _parse_player_row(tr: Node) -> PlayerGameStats:
-    """Parse a player row from the stats table.
-
-    Args:
-        tr: The table row Node containing player data.
-
-    Returns:
-        PlayerGameStats: Parsed player info including name, ID, team,
-        and agents.
-
-    """
+def _parse_player_row(cell: Node) -> PlayerGameStats:
     player = PlayerGameStats()
-    tds = tr.css("td")
 
-    td_player = tds[0] if len(tds) > 0 else None
-    td_agents = tds[1] if len(tds) > 1 else None
+    a = cell.css_first("a")
+    if a:
+        href = a.attributes.get("href", "") or ""
+        parts = href.strip("/").split("/")
+        if len(parts) >= 2:
+            with contextlib.suppress(ValueError):
+                player.player_id = int(parts[1])
 
-    if td_player:
-        a = td_player.css_first("a")
-        if a:
-            href = a.attributes.get("href", "") or ""
-            parts = href.strip("/").split("/")
-            if len(parts) >= 2:
-                with contextlib.suppress(ValueError):
-                    player.player_id = int(parts[1])
-
-        name_el = td_player.css_first(".text-of")
-        if name_el:
-            player.name = name_el.text(strip=True)
+    name_el = cell.css_first(".ovw-player-name")
+    if name_el:
+        player.name = name_el.text(strip=True)
+    else:
+        bold_el = cell.css_first("div[style*='font-weight: 700']")
+        if bold_el:
+            player.name = bold_el.text(strip=True)
         else:
-            bold_el = td_player.css_first("div[style*='font-weight: 700']")
-            if bold_el:
-                player.name = bold_el.text(strip=True)
-            else:
-                for div in td_player.css("div"):
-                    text = div.text(strip=True)
-                    if text and len(text) <= 20 and not div.css("div"):
-                        player.name = text
-                        break
-
-        team_el = td_player.css_first(".ge-text-light")
-        if team_el:
-            player.team_short = team_el.text(strip=True)
-
-        flag_el = td_player.css_first("i.flag")
-        if flag_el:
-            for cls in (flag_el.attributes.get("class") or "").split():
-                if cls.startswith("mod-") and cls != "mod-none":
-                    player.country_code = cls[4:]
-                    player.country = get_country_name(player.country_code)
+            for div in cell.css("div"):
+                text = div.text(strip=True)
+                if text and len(text) <= 20 and not div.css("div"):
+                    player.name = text
                     break
 
-    if td_agents:
-        for img in td_agents.css("img"):
-            alt = img.attributes.get("alt", "") or ""
-            if alt:
-                player.agents.append(alt.title())
+    team_el = cell.css_first(".ovw-player-tag")
+    if team_el:
+        player.team_short = team_el.text(strip=True)
+
+    flag_el = cell.css_first("i.flag")
+    if flag_el:
+        for cls in (flag_el.attributes.get("class") or "").split():
+            if cls.startswith("mod-") and cls != "mod-none":
+                player.country_code = cls[4:]
+                player.country = get_country_name(player.country_code)
+                break
+
+    for img in cell.css(".ovw-agents img"):
+        alt = img.attributes.get("alt", "") or ""
+        if alt:
+            player.agents.append(alt.title())
 
     return player
 
 
+def _parse_kda_cell(cell: Node) -> tuple:
+    kills_o = kills_a = kills_d = None
+    deaths_o = deaths_a = deaths_d = None
+    assists_o = assists_a = assists_d = None
+
+    for stat_span in cell.css("span.ovw-kda-stat"):
+        col = stat_span.attributes.get("data-col", "")
+        both_el = stat_span.css_first("span.mod-both")
+        t_el = stat_span.css_first("span.mod-t")
+        ct_el = stat_span.css_first("span.mod-ct")
+        both = _parse_int(both_el.text(strip=True)) if both_el is not None else None
+        t = _parse_int(t_el.text(strip=True)) if t_el is not None else None
+        ct = _parse_int(ct_el.text(strip=True)) if ct_el is not None else None
+        if col == "kills":
+            kills_o, kills_a, kills_d = both, t, ct
+        elif col == "deaths":
+            deaths_o, deaths_a, deaths_d = both, t, ct
+        elif col == "assists":
+            assists_o, assists_a, assists_d = both, t, ct
+
+    return (kills_o, kills_a, kills_d, deaths_o, deaths_a, deaths_d, assists_o, assists_a, assists_d)
+
+
 def _parse_table(table: Node) -> list[PlayerGameStats]:
-    """Parse an entire player stats table into PlayerGameStats list.
-
-    Args:
-        table: The table Node containing player stat rows.
-
-    Returns:
-        list[PlayerGameStats]: Parsed player stats with side-specific
-        breakdowns.
-
-    """
     players: list[PlayerGameStats] = []
-    rows = table.css("tbody tr")
-    for tr in rows:
-        tds = tr.css("td")
-        if len(tds) < 14:
+    rows = table.css("div.ovw-row")
+    for row in rows:
+        cls = row.attributes.get("class", "") or ""
+        if "mod-head" in cls:
             continue
 
-        player = _parse_player_row(tr)
+        cells = row.css("div.ovw-cell")
+        if len(cells) < 11:
+            continue
 
-        stat_tds = tds[2:14]
+        player = _parse_player_row(cells[0])
 
-        overall_vals = []
-        attack_vals = []
-        defend_vals = []
+        rating_vals = _parse_stat_cell(cells[1])
+        acs_vals = _parse_stat_cell(cells[2])
+        kills_vals, deaths_vals, assists_vals = None, None, None
+        kda_vals = _parse_kda_cell(cells[3])
+        kills_vals = (kda_vals[0], kda_vals[1], kda_vals[2])
+        deaths_vals = (kda_vals[3], kda_vals[4], kda_vals[5])
+        assists_vals = (kda_vals[6], kda_vals[7], kda_vals[8])
+        kd_diff_vals = _parse_stat_cell(cells[4])
+        kast_vals = _parse_stat_cell(cells[5])
+        adr_vals = _parse_stat_cell(cells[6])
+        hs_percent_vals = _parse_stat_cell(cells[7])
+        first_kills_vals = _parse_stat_cell(cells[8])
+        first_deaths_vals = _parse_stat_cell(cells[9])
+        fk_fd_diff_vals = _parse_stat_cell(cells[10])
 
-        for td in stat_tds:
-            o, a, d = _parse_stat_cell(td)
-            overall_vals.append(o)
-            attack_vals.append(a)
-            defend_vals.append(d)
-
-        def _build_side(vals) -> SideStats:
+        def _build_side(
+            rating_t, acs_t, kills_t, deaths_t, assists_t, kd_diff_t, kast_t, adr_t, hs_percent_t, first_kills_t, first_deaths_t, fk_fd_diff_t,
+        ) -> SideStats:
             return SideStats(
-                rating=vals[0],
-                acs=vals[1],
-                kills=vals[2],
-                deaths=vals[3],
-                assists=vals[4],
-                kd_diff=vals[5],
-                kast=vals[6],
-                adr=vals[7],
-                hs_percent=vals[8],
-                first_kills=vals[9],
-                first_deaths=vals[10],
-                fk_fd_diff=vals[11],
+                rating=rating_t,
+                acs=acs_t,
+                kills=kills_t,
+                deaths=deaths_t,
+                assists=assists_t,
+                kd_diff=kd_diff_t,
+                kast=kast_t,
+                adr=adr_t,
+                hs_percent=hs_percent_t,
+                first_kills=first_kills_t,
+                first_deaths=first_deaths_t,
+                fk_fd_diff=fk_fd_diff_t,
             )
 
         player.stats = PlayerStats(
-            overall=_build_side(overall_vals),
-            attack=_build_side(attack_vals),
-            defend=_build_side(defend_vals),
+            overall=_build_side(
+                rating_vals[0], acs_vals[0], kills_vals[0], deaths_vals[0], assists_vals[0],
+                kd_diff_vals[0], kast_vals[0], adr_vals[0], hs_percent_vals[0],
+                first_kills_vals[0], first_deaths_vals[0], fk_fd_diff_vals[0],
+            ),
+            attack=_build_side(
+                rating_vals[1], acs_vals[1], kills_vals[1], deaths_vals[1], assists_vals[1],
+                kd_diff_vals[1], kast_vals[1], adr_vals[1], hs_percent_vals[1],
+                first_kills_vals[1], first_deaths_vals[1], fk_fd_diff_vals[1],
+            ),
+            defend=_build_side(
+                rating_vals[2], acs_vals[2], kills_vals[2], deaths_vals[2], assists_vals[2],
+                kd_diff_vals[2], kast_vals[2], adr_vals[2], hs_percent_vals[2],
+                first_kills_vals[2], first_deaths_vals[2], fk_fd_diff_vals[2],
+            ),
         )
 
         players.append(player)
@@ -319,7 +337,7 @@ def parse_players_stats(html: HTMLParser, game_id: str = "all") -> PlayersStats:
             if not result.map_name:
                 result.map_name = map_div.text(strip=True)
 
-    tables = game_div.css("table.wf-table-inset.mod-overview")
+    tables = game_div.css("div.ovw-table")
     if len(tables) < 2:
         return result
 

--- a/tests/players/agents/test_parser.py
+++ b/tests/players/agents/test_parser.py
@@ -66,16 +66,6 @@ class TestSyncYuvi:
         result = client.player.agents(46051, timespan="all")
         assert result.agents[0].apr is None or result.agents[0].apr >= 0
 
-    def test_first_agent_fkpr(self, client, mock_vlr):
-        self._mock_yuvi(mock_vlr)
-        result = client.player.agents(46051, timespan="all")
-        assert result.agents[0].fkpr is None or result.agents[0].fkpr >= 0
-
-    def test_first_agent_fdpr(self, client, mock_vlr):
-        self._mock_yuvi(mock_vlr)
-        result = client.player.agents(46051, timespan="all")
-        assert result.agents[0].fdpr is None or result.agents[0].fdpr >= 0
-
     def test_first_agent_kills(self, client, mock_vlr):
         self._mock_yuvi(mock_vlr)
         result = client.player.agents(46051, timespan="all")

--- a/tests/team/placements/test_parser.py
+++ b/tests/team/placements/test_parser.py
@@ -25,7 +25,7 @@ class TestParseTeamPlacements:
         result = parse_team_placements(html, 1034)
 
         assert result.team_id == 1034
-        assert result.total_winnings == 1585375
+        assert result.total_winnings == 1925375
         assert result.total_winnings_currency == "$"
         assert len(result.placements) > 0
 

--- a/tests/team/stats/test_parser.py
+++ b/tests/team/stats/test_parser.py
@@ -62,18 +62,18 @@ class TestParseTeamStats:
 
         haven = next((m for m in result.maps if m.map_name == "Haven"), None)
         assert haven is not None
-        assert haven.games_played == 129
-        assert haven.win_rate == 73.0
-        assert haven.wins == 94
-        assert haven.losses == 35
-        assert haven.attack_first == 66
-        assert haven.defense_first == 63
+        assert haven.games_played == 132
+        assert haven.win_rate == 72.0
+        assert haven.wins == 95
+        assert haven.losses == 37
+        assert haven.attack_first == 68
+        assert haven.defense_first == 64
         assert haven.attack_round_win_rate == 57.0
-        assert haven.attack_rounds_won == 743
-        assert haven.attack_rounds_lost == 558
+        assert haven.attack_rounds_won == 755
+        assert haven.attack_rounds_lost == 573
         assert haven.defense_round_win_rate == 61.0
-        assert haven.defense_rounds_won == 805
-        assert haven.defense_rounds_lost == 519
+        assert haven.defense_rounds_won == 820
+        assert haven.defense_rounds_lost == 532
 
     def test_parse_team_with_minimal_map_data(self):
         html = _load_html(17676, "stats.html")

--- a/uv.lock
+++ b/uv.lock
@@ -927,7 +927,7 @@ wheels = [
 
 [[package]]
 name = "vlrdevapi"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
… fields

- Updated series/player overview and player agent/profile parsers to match vlr.gg's new div-based layout and st-table agent rows
- Removed fkpr/fdpr fields from AgentStats model (vlr.gg consolidated into a single FK:FD ratio column)
- Updated team placement and stats test assertions to match current vlr.gg data
- Bumped version to 2.0.1 across pyproject.toml, __init__.py, uv.lock, changelogs, and docs
- Added Changelog page to docs-py site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 2.0.1.

* **Bug Fixes**
  * Updated player and agent statistics parsing for the latest page layout.
  * Improved player profile agent data handling with an all-time fallback.
  * Removed deprecated first-kill and first-death rate fields; total values remain available.
  * Updated team statistics and winnings to reflect current data.

* **Documentation**
  * Added changelog documentation and updated the agent statistics schema reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->