### PR TITLE
Fix check_pagination reporting phantom next page on terminal pages

### DIFF
--- a/src/vlrdevapi/_matches/common.py
+++ b/src/vlrdevapi/_matches/common.py
@@ -1,6 +1,8 @@
 """Shared utilities for match enrichment and parsing across live/upcoming/completed modules."""
 
+import contextlib
 import logging
+import re
 from collections.abc import Callable
 from datetime import date, datetime, tzinfo
 from typing import Any, Protocol
@@ -55,20 +57,42 @@ def parse_date_header(text: str) -> date | None:
 
 
 def check_pagination(html: HTMLParser) -> bool:
-    """Check whether the page has pagination links to additional pages.
+    """Check whether a page after the current one exists.
+
+    The active page is rendered as a ``mod-active`` span while other pages
+    are anchor links. A terminal page still links back to earlier pages, so
+    the mere presence of page links does not imply a next page. Compare the
+    active page number against the highest page number offered instead.
 
     Args:
         html: Parsed HTML document.
 
     Returns:
-        ``True`` if at least one page link exists, ``False`` otherwise.
+        ``True`` if a page after the active one exists, ``False`` otherwise.
 
     """
     pagination_el = html.css_first("div.action-container-pages")
-    if pagination_el:
-        page_links = pagination_el.css("a.btn.mod-page")
-        return len(page_links) > 0
-    return False
+    if pagination_el is None:
+        return False
+
+    current_page = 1
+    active = pagination_el.css_first(".btn.mod-page.mod-active")
+    if active:
+        with contextlib.suppress(ValueError):
+            current_page = int(active.text(strip=True))
+
+    max_page = current_page
+    for btn in pagination_el.css(".btn.mod-page"):
+        text = btn.text(strip=True)
+        try:
+            max_page = max(max_page, int(text))
+        except ValueError:
+            href = btn.attributes.get("href") or ""
+            page_match = re.search(r"page=(\d+)", href)
+            if page_match:
+                max_page = max(max_page, int(page_match.group(1)))
+
+    return current_page < max_page
 
 
 # ---------------------------------------------------------------------------

--- a/tests/matches/test_check_pagination.py
+++ b/tests/matches/test_check_pagination.py
@@ -1,0 +1,30 @@
+from selectolax.parser import HTMLParser
+
+from vlrdevapi._matches.common import check_pagination
+
+
+def _page(active: int, last: int) -> HTMLParser:
+    btns = []
+    for p in range(1, last + 1):
+        if p == active:
+            btns.append(f'<span class="btn mod-page mod-active">{p}</span>')
+        else:
+            btns.append(f'<a href="/matches/?page={p}" class="btn mod-page">{p}</a>')
+    return HTMLParser(f'<div class="action-container-pages">{"".join(btns)}</div>')
+
+
+def test_middle_page_has_next():
+    assert check_pagination(_page(active=2, last=5)) is True
+
+
+def test_terminal_page_no_next():
+    # Last page still links back to earlier pages; must not report a next page.
+    assert check_pagination(_page(active=5, last=5)) is False
+
+
+def test_single_page_no_next():
+    assert check_pagination(_page(active=1, last=1)) is False
+
+
+def test_no_pagination_element():
+    assert check_pagination(HTMLParser("<div></div>")) is False


### PR DESCRIPTION
check_pagination returned True whenever any page anchor existed. On the last page the active page is a mod-active span while earlier pages remain anchors, so those backward links caused a false has_next_page=True and collect_all_pages_sync then fetched a nonexistent page.

Compare the active page number against the highest page offered (current_page < max_page), mirroring the existing _event/list logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination handling to accurately identify when additional result pages are available.
  - Added safeguards for missing, malformed, or nonnumeric pagination controls.
  - Corrected behavior for middle, final, single-page, and pagination-free results.

- **Tests**
  - Added coverage for next-page detection and edge cases across paginated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->